### PR TITLE
Add configurable default progress bar

### DIFF
--- a/accelerator/docs/callbacks.md
+++ b/accelerator/docs/callbacks.md
@@ -1,0 +1,29 @@
+# Progress Bars
+
+`accelerator` can provide a progress bar callback so that training steps offer
+immediate feedback. No progress bar is shown by default, but different progress
+implementations can be enabled through the global configuration.
+
+## Selecting a Progress Bar
+
+The choice of progress bar is controlled via the `progress_bar` field in the
+configuration (see `configs/main.yaml`). Supported values are:
+
+- `"tqdm"` – enable the tqdm-based progress bar.
+- `"rich"` – use the rich-library based progress bar.
+- `null` – disable the progress bar entirely (default).
+
+For example, to enable the rich progress bar:
+
+```yaml
+progress_bar: rich
+```
+
+To disable any progress display:
+
+```yaml
+progress_bar: null
+```
+
+User-provided callbacks can still be added through the standard `callbacks`
+configuration and will be appended to the always-on set.

--- a/accelerator/runtime/callbacks/always_on.py
+++ b/accelerator/runtime/callbacks/always_on.py
@@ -4,16 +4,13 @@ These constructors return instances of callbacks that are considered
 core to the training loop and are therefore attached by default by the
 :class:`ComponentManager`.
 """
+
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from .base import BaseCallback
-from .progress import (
-    StepEpochTrackerCallback,
-    TimeTrackingCallback,
-    TqdmProgressBar,
-)
+from .progress import RichProgressBar, StepEpochTrackerCallback, TimeTrackingCallback, TqdmProgressBar
 
 
 def create_step_epoch_tracker_callback() -> StepEpochTrackerCallback:
@@ -26,19 +23,34 @@ def create_time_tracking_callback() -> TimeTrackingCallback:
     return TimeTrackingCallback()
 
 
-def create_progress_bar_callback() -> TqdmProgressBar:
-    """Return a default progress bar callback.
+def create_progress_bar_callback(kind: str = "tqdm") -> BaseCallback:
+    """Return a progress bar callback instance.
 
-    Currently this uses :class:`~accelerator.runtime.callbacks.progress.TqdmProgressBar`.
+    Args:
+        kind: Type of progress bar to create. Supported values are
+            ``"tqdm"`` and ``"rich"``.
+
+    Returns:
+        Instantiated progress bar callback.
+
+    Raises:
+        ValueError: If an unsupported progress bar type is provided.
     """
-    return TqdmProgressBar()
+    kind = kind.lower()
+    if kind == "rich":
+        return RichProgressBar()
+    if kind == "tqdm":
+        return TqdmProgressBar()
+    raise ValueError(f"Unsupported progress bar type: {kind}")
 
 
-def create_always_on_callbacks(include_progress: bool = False) -> List[BaseCallback]:
+def create_always_on_callbacks(progress_bar: Optional[str] = None) -> List[BaseCallback]:
     """Create the list of callbacks that are always enabled.
 
     Args:
-        include_progress: Whether to include a default progress bar. Defaults to False.
+        progress_bar: Which progress bar to use. Supported values are
+            ``"tqdm"`` and ``"rich"``. Pass ``None`` to disable the progress
+            bar entirely. Defaults to ``None``.
 
     Returns:
         List of instantiated callback objects.
@@ -47,6 +59,6 @@ def create_always_on_callbacks(include_progress: bool = False) -> List[BaseCallb
         create_step_epoch_tracker_callback(),
         create_time_tracking_callback(),
     ]
-    if include_progress:
-        callbacks.append(create_progress_bar_callback())
+    if progress_bar:
+        callbacks.append(create_progress_bar_callback(progress_bar))
     return callbacks

--- a/accelerator/runtime/context/component.py
+++ b/accelerator/runtime/context/component.py
@@ -1,12 +1,13 @@
-from typing import Any, Dict, List, Optional, Callable, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+
 from omegaconf import DictConfig
+
+from accelerator.utilities.base_container import BaseContainer
 from accelerator.utilities.hydra_utils import instantiate
 from accelerator.utilities.logging import get_logger
-from accelerator.utilities.base_container import BaseContainer
 from accelerator.utilities.model_utils.unwrap import unwrap_model
 
-
-T = TypeVar('T')
+T = TypeVar("T")
 logger = get_logger(__name__)
 
 
@@ -16,86 +17,77 @@ class ComponentManager(BaseContainer):
         self._components: Dict[str, Any] = {}
         self._manual_components: Dict[str, Any] = {}
         self._factories: Dict[str, Callable[[], Any]] = {}
-        self._dependency_map: Dict[str, List[str]] = {
-            'model': ['optimizer', 'scheduler'],
-            'optimizer': ['scheduler']
-        }
+        self._dependency_map: Dict[str, List[str]] = {"model": ["optimizer", "scheduler"], "optimizer": ["scheduler"]}
         self._setup_default_factories()
-    
 
     def _setup_default_factories(self):
-        self._factories.update({
-            'model': self._create_model,
-            'data': self._create_data,
-            'optimizer': self._create_optimizer,
-            'scheduler': self._create_scheduler,
-            'callbacks': self._create_callbacks,
-            'distributed': self._create_distributed,
-        })
-    
+        self._factories.update(
+            {
+                "model": self._create_model,
+                "data": self._create_data,
+                "optimizer": self._create_optimizer,
+                "scheduler": self._create_scheduler,
+                "callbacks": self._create_callbacks,
+                "distributed": self._create_distributed,
+            }
+        )
 
     def register_factory(self, name: str, factory: Callable[[], Any]):
         self._factories[name] = factory
-    
 
     def set_component(self, name: str, instance: Any):
         self._manual_components[name] = instance
         self._components[name] = self._process_component(name, instance)
         self._rebuild_dependents(name)
-    
 
     def get_component(self, name: str) -> Optional[Any]:
         if name in self._components:
             return self._components[name]
-        
+
         if name not in self._manual_components and name in self._factories:
             self._create_component_from_factory(name)
-        
+
         return self._components.get(name)
-    
 
     def has_component(self, name: str) -> bool:
         return name in self._components or name in self._manual_components
-    
 
     def configure_dependencies(self, dependency_map: Dict[str, List[str]]):
         self._dependency_map = dependency_map
-    
 
     def _process_component(self, name: str, instance: Any) -> Any:
-        if name == 'model':
+        if name == "model":
             return self._process_model(instance)
-        if name == 'data':
+        if name == "data":
             return self._process_data(instance)
         return instance
-    
 
     def _process_data(self, data):
         from accelerator.runtime.datamodule.datamodule import DataModule
+
         if isinstance(data, DataModule):
             return data
-        
+
         if isinstance(data, dict) and len(data.values()):
             return DataModule(**data)
-        
+
         else:
-            data_config = self.config.get('datamodule', {})
+            data_config = self.config.get("datamodule", {})
             return DataModule.initialize_from_config(data_config)
-    
 
     def _process_model(self, model):
         from accelerator.runtime.model.accelerated_model import AcceleratedModel
+
         if isinstance(model, AcceleratedModel) or isinstance(unwrap_model(model), AcceleratedModel):
             return model
         else:
-            model_config = self.config.get('model', {})
+            model_config = self.config.get("model", {})
             return AcceleratedModel(model, model_config)
-    
 
     def _create_component_from_factory(self, name: str):
         if name not in self._factories:
             return
-        
+
         try:
             result = self._factories[name]()
             if result:
@@ -104,63 +96,59 @@ class ComponentManager(BaseContainer):
         except Exception as e:
             logger.error(f"Failed to create component {name}: {e}")
             raise
-    
 
     def _rebuild_dependents(self, changed_component: str):
         for dependent in self._dependency_map.get(changed_component, []):
             if dependent not in self._manual_components:
                 self._create_component_from_factory(dependent)
-    
 
     def _create_model(self):
         from accelerator.runtime.model.accelerated_model import AcceleratedModel
-        
-        if 'model' not in self.config or self.config.model is None:
+
+        if "model" not in self.config or self.config.model is None:
             return None
         core_model = instantiate(self.config.model.model_core)
         return AcceleratedModel(core_model, self.config.model)
-    
 
     def _create_data(self):
         from accelerator.runtime.datamodule.datamodule import DataModule
-        
-        if 'datamodule' not in self.config or self.config.datamodule is None:
+
+        if "datamodule" not in self.config or self.config.datamodule is None:
             return None
         return DataModule.initialize_from_config(self.config.datamodule)
-    
 
     def _create_optimizer(self):
-        tc = self.config.get('training_components', {})
-        if not tc or 'optimizer' not in tc:
+        tc = self.config.get("training_components", {})
+        if not tc or "optimizer" not in tc:
             return None
-        
-        model = self.get_component('model')
+
+        model = self.get_component("model")
         if not model:
             return None
-        
+
         return instantiate(tc.optimizer, params=[p for p in model.parameters() if p.requires_grad])
-    
 
     def _create_scheduler(self):
-        tc = self.config.get('training_components', {})
-        if not tc or 'scheduler' not in tc:
+        tc = self.config.get("training_components", {})
+        if not tc or "scheduler" not in tc:
             return None
-        
-        optimizer = self.get_component('optimizer')
+
+        optimizer = self.get_component("optimizer")
         if not optimizer:
             return None
-        
+
         return instantiate(tc.scheduler, optimizer=optimizer)
-    
 
     def _create_callbacks(self):
-        from accelerator.runtime.callbacks.manager import CallbackManager
         from accelerator.runtime.callbacks.always_on import create_always_on_callbacks
+        from accelerator.runtime.callbacks.manager import CallbackManager
 
-        cb_cfg = self.config.get('callbacks', {})
+        cb_cfg = self.config.get("callbacks", {})
+
+        progress_bar = self.config.get("progress_bar")
 
         # Instantiate always-on callbacks first
-        manager = CallbackManager(create_always_on_callbacks())
+        manager = CallbackManager(create_always_on_callbacks(progress_bar))
 
         # Append user defined callbacks, avoiding duplicates
         if cb_cfg:
@@ -170,37 +158,32 @@ class ComponentManager(BaseContainer):
                     manager.add_callback(cb)
 
         return manager
-    
-    
+
     def _create_distributed(self):
-        if 'engine' not in self.config:
+        if "engine" not in self.config:
             return None
         engine = instantiate(self.config.engine)
         return engine
-    
 
     def clear(self):
         self._components.clear()
         self._manual_components.clear()
-    
 
     def list_components(self) -> List[str]:
         return list(set(self._components.keys()) | set(self._manual_components.keys()))
-    
 
     def _get_summary_info(self) -> str:
         total_factories = len(self._factories)
         active_components = len(self._components)
         return f"{active_components}/{total_factories} active"
-    
 
     def _get_representation_sections(self) -> List[Tuple[str, List[str]]]:
         sections = []
-        
+
         if self.config:
-            config_sections = len(self.config) if hasattr(self.config, '__len__') else 1
+            config_sections = len(self.config) if hasattr(self.config, "__len__") else 1
             sections.append(("Configuration", [f"{config_sections} sections"]))
-        
+
         if self._components:
             active_items = []
             for name, component in self._components.items():
@@ -208,17 +191,17 @@ class ComponentManager(BaseContainer):
                 source = "manual" if name in self._manual_components else "factory"
                 active_items.append(f"{name}: {component_type} ({source})")
             sections.append(("Active Components", active_items))
-        
+
         available_factories = set(self._factories.keys()) - set(self._components.keys())
         if available_factories:
             factory_items = list(sorted(available_factories))
             sections.append(("Available Factories", factory_items))
-        
+
         if self._dependency_map:
             dependency_items = []
             for component, deps in self._dependency_map.items():
-                deps_str = ', '.join(deps)
+                deps_str = ", ".join(deps)
                 dependency_items.append(f"{component} → {deps_str}")
             sections.append(("Dependencies", dependency_items))
-        
+
         return sections

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -8,16 +8,14 @@ defaults:
   - hydra: default.yaml
   - extras: default.yaml
 
-
   # indices
   - /training_components/transform/loss/index@index.LT
   - /training_components/transform/input/index@index.IT
   - /training_components/loss/index@index.LOSSES
 
-  
   - checkpoint/default@checkpoint_load
   - checkpoint/default@checkpoint_save
-  
+
   - paths: default
   - training_components: default
   - datamodule: null
@@ -26,10 +24,10 @@ defaults:
 
 # configurable
 project_name: transairaw # < project name used for folder creation
-base_path: './' # base path where everything will be stored
+base_path: "./" # base path where everything will be stored
 exp_name: "debug_mlflow" # experiment name
 exp_num: 0 # experiment number
-        
+
 # start setup
 seed: 228
 entry_point: accelerator # entry point specified in MLProject
@@ -37,16 +35,16 @@ nnodes: 1
 nproc_per_node: 1
 gpu_idxs: ~
 
-
-tags: ['dev', 'debug']
-
+tags: ["dev", "debug"]
 
 verify_model: False
 verify_dataloader: False
 verify_loss: False
 
-
 load_from_previous: False
 
 job_name: ${zero_pad:${exp_num}, 4}_${exp_name}
 attempt_id: ${uuid4:8}
+
+# Progress bar configuration: set to "tqdm" or "rich" to enable, null disables
+progress_bar: null


### PR DESCRIPTION
## Summary
- default progress bar disabled (null) with option to enable `tqdm` or `rich`
- only register a progress bar callback when one is specified
- document how to enable or disable the progress bar

## Testing
- `pre-commit run --files accelerator/docs/callbacks.md accelerator/runtime/callbacks/always_on.py accelerator/runtime/context/component.py configs/main.yaml`
- `pytest -q` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bdd182ebd88325b9cbaf277159b8ce