### PR TITLE
Add NodeInterpreter for node-level stats routing

### DIFF
--- a/accelerator/tools/analysis/model_analysis/__init__.py
+++ b/accelerator/tools/analysis/model_analysis/__init__.py
@@ -1,3 +1,4 @@
 from .graph import NodeSpec, trace_model
+from .runner import NodeInterpreter
 
-__all__ = ["NodeSpec", "trace_model"]
+__all__ = ["NodeSpec", "trace_model", "NodeInterpreter"]

--- a/accelerator/tools/analysis/model_analysis/runner.py
+++ b/accelerator/tools/analysis/model_analysis/runner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import Any, Callable, List
+
+import torch
+from torch.fx import GraphModule, Interpreter, Node
+
+
+class NodeInterpreter(Interpreter):
+    """Interpreter that routes tensors to a ``StatsRouter``.
+
+    Each node's inputs and outputs are normalized to a list of tensors and
+    dispatched to the provided ``stats_router`` for statistics collection.
+    Backward statistics are captured via autograd hooks registered on the
+    forward outputs.
+    """
+
+    def __init__(self, gm: GraphModule, stats_router: Any) -> None:
+        super().__init__(gm)
+        self.stats_router = stats_router
+
+    # ---------------------------------------------------------------------
+    # Utility helpers
+    # ---------------------------------------------------------------------
+    @staticmethod
+    def _tensor_list(obj: Any) -> List[torch.Tensor]:
+        """Recursively collect tensors from ``obj`` into a list."""
+
+        tensors: List[torch.Tensor] = []
+
+        def collect(x: Any) -> None:
+            if isinstance(x, torch.Tensor):
+                tensors.append(x)
+            elif isinstance(x, (list, tuple, set)):
+                for v in x:
+                    collect(v)
+            elif isinstance(x, dict):
+                for v in x.values():
+                    collect(v)
+
+        collect(obj)
+        return tensors
+
+    def _dispatch(self, method: str, node: Node, tensors: List[torch.Tensor]) -> None:
+        """Send ``tensors`` to the stats router for ``method`` stage."""
+
+        router = self.stats_router
+        if router is None:
+            return
+        if hasattr(router, method):
+            getattr(router, method)(node, tensors)
+        elif callable(router):
+            router(node, method, tensors)
+
+    # ------------------------------------------------------------------
+    # FX Interpreter overrides
+    # ------------------------------------------------------------------
+    def run_node(self, node: Node) -> Any:  # type: ignore[override]
+        args, kwargs = self.fetch_args_kwargs_from_env(node)
+        inputs = self._tensor_list((args, kwargs))
+        self._dispatch("forward_pre", node, inputs)
+
+        result = getattr(self, node.op)(node.target, args, kwargs)
+
+        outputs = self._tensor_list(result)
+        self._dispatch("forward_post", node, outputs)
+
+        for t in outputs:
+            if t.requires_grad:
+                t.register_hook(partial(self._backward_hook, node))
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Autograd hook
+    # ------------------------------------------------------------------
+    def _backward_hook(self, node: Node, grad: torch.Tensor) -> torch.Tensor:
+        grads = self._tensor_list(grad)
+        self._dispatch("backward", node, grads)
+        return grad
+


### PR DESCRIPTION
## Summary
- add `NodeInterpreter` class to execute FX graphs while routing tensors to a `StatsRouter`
- export `NodeInterpreter` in `model_analysis` package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde415e8d483259defadec925f2b9e