### PR TITLE
feat: support per-node stats collectors

### DIFF
--- a/accelerator/tools/analysis/stats/collector.py
+++ b/accelerator/tools/analysis/stats/collector.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple, Type
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Base collectors
+# ---------------------------------------------------------------------------
+
+
+class _BaseTensorCollector:
+    """Base class for simple tensor statistics collectors."""
+
+    name: str
+
+    def __init__(self, channel_dim: int) -> None:
+        self.channel_dim = channel_dim
+
+    def update(self, tensor: torch.Tensor) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def compute(self) -> torch.Tensor:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class MeanTensorCollector(_BaseTensorCollector):
+    """Collector computing per-channel mean values."""
+
+    name = "mean"
+
+    def __init__(self, channel_dim: int) -> None:
+        super().__init__(channel_dim)
+        self._sum: torch.Tensor | None = None
+        self._count: int = 0
+
+    def update(self, tensor: torch.Tensor) -> None:  # pragma: no cover - simple math
+        dims = tuple(d for d in range(tensor.dim()) if d != self.channel_dim)
+        summed = tensor.float().sum(dim=dims)
+        count = tensor.numel() // tensor.size(self.channel_dim)
+        if self._sum is None:
+            self._sum = summed
+        else:
+            self._sum = self._sum + summed
+        self._count += count
+
+    def compute(self) -> torch.Tensor:  # pragma: no cover - simple math
+        if self._sum is None or self._count == 0:
+            return torch.tensor(0.0)
+        return self._sum / self._count
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StatsConfig:
+    """Configuration for tensor statistics collection.
+
+    Parameters
+    ----------
+    channel_dim:
+        Dimension treated as channel dimension. Reduction is performed over all
+        other dimensions.
+    collectors:
+        Iterable of collector classes used for gathering statistics. Each class
+        must derive from ``_BaseTensorCollector``.
+    """
+
+    channel_dim: int = 0
+    collectors: Tuple[Type[_BaseTensorCollector], ...] = (MeanTensorCollector,)
+
+
+# ---------------------------------------------------------------------------
+# Tensor stats collection
+# ---------------------------------------------------------------------------
+
+
+class TensorStatsCollector:
+    """Collects activation and gradient statistics per FX node."""
+
+    def __init__(
+        self,
+        activation_config: StatsConfig,
+        gradient_config: StatsConfig,
+        activation_configs: Dict[str, StatsConfig] | None = None,
+        gradient_configs: Dict[str, StatsConfig] | None = None,
+    ) -> None:
+        self.default_activation_config = activation_config
+        self.default_gradient_config = gradient_config
+        self.activation_configs = activation_configs or {}
+        self.gradient_configs = gradient_configs or {}
+
+        self.activation_collectors: Dict[str, List[_BaseTensorCollector]] = {}
+        self.gradient_collectors: Dict[str, List[_BaseTensorCollector]] = {}
+
+        for node, cfg in self.activation_configs.items():
+            self.activation_collectors[node] = [c(channel_dim=cfg.channel_dim) for c in cfg.collectors]
+        for node, cfg in self.gradient_configs.items():
+            self.gradient_collectors[node] = [c(channel_dim=cfg.channel_dim) for c in cfg.collectors]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _get_collectors(
+        self,
+        node: str,
+        configs: Dict[str, StatsConfig],
+        store: Dict[str, List[_BaseTensorCollector]],
+        default_config: StatsConfig,
+    ) -> List[_BaseTensorCollector]:
+        if node not in store:
+            cfg = configs.get(node, default_config)
+            store[node] = [c(channel_dim=cfg.channel_dim) for c in cfg.collectors]
+        return store[node]
+
+    # ------------------------------------------------------------------
+    # Update methods
+    # ------------------------------------------------------------------
+    def update_activation(self, node: str, tensors: Iterable[torch.Tensor]) -> None:
+        collectors = self._get_collectors(
+            node, self.activation_configs, self.activation_collectors, self.default_activation_config
+        )
+        for t in tensors:
+            for c in collectors:
+                c.update(t)
+
+    def update_gradient(self, node: str, tensors: Iterable[torch.Tensor]) -> None:
+        collectors = self._get_collectors(
+            node, self.gradient_configs, self.gradient_collectors, self.default_gradient_config
+        )
+        for t in tensors:
+            for c in collectors:
+                c.update(t)
+
+    # ------------------------------------------------------------------
+    # Compute results
+    # ------------------------------------------------------------------
+    def compute(self) -> Tuple[Dict[str, Dict[str, torch.Tensor]], Dict[str, Dict[str, torch.Tensor]]]:
+        activations = {
+            node: {collector.name: collector.compute() for collector in collectors}
+            for node, collectors in self.activation_collectors.items()
+        }
+        gradients = {
+            node: {collector.name: collector.compute() for collector in collectors}
+            for node, collectors in self.gradient_collectors.items()
+        }
+        return activations, gradients

--- a/tests/test_stats_collectors.py
+++ b/tests/test_stats_collectors.py
@@ -1,0 +1,37 @@
+import torch
+
+from accelerator.tools.analysis.stats.collector import StatsConfig, TensorStatsCollector
+
+
+def test_per_layer_channel_dim_configs():
+    default_cfg = StatsConfig(channel_dim=0)
+    layer1_cfg = StatsConfig(channel_dim=0)
+    layer2_cfg = StatsConfig(channel_dim=1)
+
+    activation_configs = {"layer1": layer1_cfg, "layer2": layer2_cfg}
+    gradient_configs = {"layer1": layer1_cfg, "layer2": layer2_cfg}
+
+    collector = TensorStatsCollector(
+        activation_config=default_cfg,
+        gradient_config=default_cfg,
+        activation_configs=activation_configs,
+        gradient_configs=gradient_configs,
+    )
+
+    tensor = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+
+    collector.update_activation("layer1", [tensor])
+    collector.update_activation("layer2", [tensor])
+
+    grad = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    collector.update_gradient("layer1", [grad])
+    collector.update_gradient("layer2", [grad])
+
+    activations, gradients = collector.compute()
+
+    assert torch.allclose(activations["layer1"]["mean"], torch.tensor([1.5, 3.5]))
+    assert torch.allclose(activations["layer2"]["mean"], torch.tensor([2.0, 3.0]))
+
+    assert torch.allclose(gradients["layer1"]["mean"], torch.tensor([1.5, 3.5]))
+    assert torch.allclose(gradients["layer2"]["mean"], torch.tensor([2.0, 3.0]))
+


### PR DESCRIPTION
## Summary
- add a simple stats collection framework with a per-node `TensorStatsCollector`
- collect means of activations and gradients by node with configurable channel dimension
- cover per-layer configs with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdeca798e4832583b6ac2c3f753935