### PR TITLE
Add histogram calibration using sample buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Accelerator
+
+Utilities for collecting tensor statistics.
+
+## Histogram calibration
+
+`HistogramTensorCollector` can delay histogram creation until a calibration
+buffer has gathered enough samples. Pass `calibration_size` to specify the
+number of samples per channel to accumulate. The buffer is used to determine
+bin ranges using the Freedman–Diaconis rule and is discarded once the
+histogram is initialized.

--- a/tests/test_histogram_collector.py
+++ b/tests/test_histogram_collector.py
@@ -1,0 +1,25 @@
+import torch
+
+from accelerator.tools.analysis.stats import HistogramTensorCollector
+
+
+def test_histogram_calibrates_from_sample_buffer():
+    collector = HistogramTensorCollector(channel_dim=0, calibration_size=100)
+
+    first = torch.arange(50.0).unsqueeze(0)
+    collector.update(first)
+    assert collector.hist is None
+    assert collector._calibration_buffer is not None
+    assert collector._calibration_buffer.numel() == 50
+
+    second = torch.arange(50.0, 100.0).unsqueeze(0)
+    collector.update(second)
+    assert collector.hist is not None
+    assert collector._calibration_buffer is None
+    initial_sum = collector.hist.sum().item()
+    assert initial_sum == 100
+
+    third = torch.arange(100.0, 110.0).unsqueeze(0)
+    collector.update(third)
+    assert collector._calibration_buffer is None
+    assert collector.hist.sum().item() == initial_sum + 10


### PR DESCRIPTION
## Summary
- add calibration to `HistogramTensorCollector` with sample buffering and Freedman–Diaconis bin selection
- test histogram calibration and buffer removal
- document calibration parameters in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be41c336b08325b8c050da0972de84