### PR TITLE
Add inference performance measurement utilities

### DIFF
--- a/accelerator/docs/tools.md
+++ b/accelerator/docs/tools.md
@@ -1,0 +1,27 @@
+# Tools
+
+## Performance Utilities
+
+The `accelerator.tools.performance` module offers helpers for measuring model inference speed.
+
+### `measure_inference_time`
+
+Runs a model multiple times and reports aggregated latency metrics (average, variance and percentiles).
+
+```python
+from accelerator.tools.performance import measure_inference_time
+metrics = measure_inference_time(model, inputs)
+print(metrics)
+```
+
+### `measure_per_node_inference_time`
+
+Profiles each operator executed during inference and reports average self CPU and CUDA times.
+
+```python
+from accelerator.tools.performance import measure_per_node_inference_time
+node_metrics = measure_per_node_inference_time(model, inputs)
+print(node_metrics["aten::linear"])
+```
+
+See [examples/inference_time_example.py](../examples/inference_time_example.py) for a usage example.

--- a/accelerator/tools/performance/__init__.py
+++ b/accelerator/tools/performance/__init__.py
@@ -1,0 +1,3 @@
+from .inference_time import measure_inference_time, measure_per_node_inference_time
+
+__all__ = ["measure_inference_time", "measure_per_node_inference_time"]

--- a/accelerator/tools/performance/inference_time.py
+++ b/accelerator/tools/performance/inference_time.py
@@ -1,0 +1,136 @@
+import time
+from typing import Any, Dict, Tuple
+
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+from accelerator.utilities.move_to_device import move_data_to_device
+
+
+def _prepare_inputs(inputs: Any) -> Tuple[Any, ...]:
+    if isinstance(inputs, (list, tuple)):
+        return tuple(inputs)
+    return (inputs,)
+
+
+def measure_inference_time(
+    model: torch.nn.Module,
+    inputs: Any,
+    warmup: int = 5,
+    runs: int = 50,
+    device: torch.device | str | None = None,
+) -> Dict[str, float]:
+    """Measure inference latency for a model.
+
+    Args:
+        model: Model to evaluate in ``eval`` mode.
+        inputs: Inputs to pass to the model. Can be any structure accepted by
+            :func:`move_data_to_device`.
+        warmup: Number of warmup iterations to run before timing.
+        runs: Number of timed runs to average over.
+        device: Device on which to run the model. If ``None``, uses the model's
+            current device.
+
+    Returns:
+        Dictionary containing average latency, variance, and percentile metrics
+        (p50, p90, p95, p99).
+    """
+    if device is not None:
+        device = torch.device(device)
+        model.to(device)
+    else:
+        device = next(model.parameters()).device
+
+    model.eval()
+    inputs = move_data_to_device(inputs, device)
+    inputs = _prepare_inputs(inputs)
+
+    with torch.no_grad():
+        for _ in range(warmup):
+            model(*inputs)
+
+        timings: list[float] = []
+        for _ in range(runs):
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            start = time.perf_counter()
+            model(*inputs)
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            end = time.perf_counter()
+            timings.append(end - start)
+
+    times = torch.tensor(timings)
+    metrics = {
+        "average": times.mean().item(),
+        "variance": times.var(unbiased=False).item(),
+        "p50": times.quantile(0.5).item(),
+        "p90": times.quantile(0.9).item(),
+        "p95": times.quantile(0.95).item(),
+        "p99": times.quantile(0.99).item(),
+    }
+    return metrics
+
+
+def measure_per_node_inference_time(
+    model: torch.nn.Module,
+    inputs: Any,
+    warmup: int = 5,
+    runs: int = 50,
+    device: torch.device | str | None = None,
+) -> Dict[str, Dict[str, float]]:
+    """Profile per-operator execution time for a model.
+
+    Uses :mod:`torch.profiler` to capture self CPU and CUDA times for each
+    operator executed during inference. Times are reported in seconds and
+    averaged over ``runs`` iterations.
+
+    Args:
+        model: Model to evaluate in ``eval`` mode.
+        inputs: Inputs to pass to the model. Can be any structure accepted by
+            :func:`move_data_to_device`.
+        warmup: Number of warmup iterations to run before profiling.
+        runs: Number of profiled runs to average over.
+        device: Device on which to run the model. If ``None``, uses the model's
+            current device.
+
+    Returns:
+        Dictionary mapping operator names to dictionaries containing averaged
+        CPU and CUDA self times in seconds.
+    """
+
+    if device is not None:
+        device = torch.device(device)
+        model.to(device)
+    else:
+        device = next(model.parameters()).device
+
+    model.eval()
+    inputs = move_data_to_device(inputs, device)
+    inputs = _prepare_inputs(inputs)
+
+    with torch.no_grad():
+        for _ in range(warmup):
+            model(*inputs)
+
+        activities = [ProfilerActivity.CPU]
+        if device.type == "cuda":
+            activities.append(ProfilerActivity.CUDA)
+
+        with profile(activities=activities, record_shapes=True) as prof:
+            for _ in range(runs):
+                model(*inputs)
+                if device.type == "cuda":
+                    torch.cuda.synchronize()
+
+    metrics: Dict[str, Dict[str, float]] = {}
+    for evt in prof.key_averages():
+        entry: Dict[str, float] = {}
+        if evt.self_cpu_time_total > 0:
+            entry["cpu_time_avg"] = (evt.self_cpu_time_total / runs) / 1e6
+        if hasattr(evt, "self_cuda_time_total") and evt.self_cuda_time_total > 0:
+            entry["cuda_time_avg"] = (evt.self_cuda_time_total / runs) / 1e6
+        if entry:
+            metrics[evt.key] = entry
+
+    return metrics

--- a/examples/inference_time_example.py
+++ b/examples/inference_time_example.py
@@ -1,0 +1,44 @@
+"""Example of benchmarking a simple model's inference performance."""
+
+import os
+import sys
+
+import torch
+import torch.nn as nn
+
+# Ensure the repository root is on sys.path so we can import accelerator
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from accelerator.tools.performance import (
+    measure_inference_time,
+    measure_per_node_inference_time,
+)
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(10, 10)
+
+    def forward(self, x):
+        return self.layer(x)
+
+
+def main() -> None:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = SimpleModel()
+    inputs = torch.randn(32, 10)
+
+    metrics = measure_inference_time(model, inputs, warmup=2, runs=10, device=device)
+    print("Inference time metrics:", metrics)
+
+    node_metrics = measure_per_node_inference_time(
+        model, inputs, warmup=2, runs=10, device=device
+    )
+    print("Per-node average self times (seconds):")
+    for op_name, times in list(node_metrics.items())[:5]:
+        print(f"  {op_name}: {times}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rename performance module to `inference_time`
- add `measure_per_node_inference_time` using `torch.profiler`
- update example script and docs for new profiling helper

## Testing
- `python examples/inference_time_example.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be4378c3f88325b7496d534ab452a6