### PR TITLE
Track input activations in model analysis

### DIFF
--- a/accelerator/cli/analyze.py
+++ b/accelerator/cli/analyze.py
@@ -151,9 +151,9 @@ class ModelAnalysisCLI:
             loss = result.sum() if isinstance(result, torch.Tensor) else result[0].sum()
             loss.backward()
 
-        activations, gradients = collector.compute()
+        input_activations, activations, gradients = collector.compute()
         out_file = output or "analysis_stats.json"
-        save_tensor_stats(activations, gradients, out_file)
+        save_tensor_stats(activations, gradients, out_file, input_activations)
         return out_file
 
 

--- a/accelerator/tools/analysis/model_analysis/router.py
+++ b/accelerator/tools/analysis/model_analysis/router.py
@@ -47,6 +47,11 @@ class StatsRouter:
         return True
 
     # ------------------------------------------------------------------
+    def forward_pre(self, node, tensors) -> None:
+        if self._match(node.name):
+            self.collector.update_activation(node.name, tensors, input=True)
+
+    # ------------------------------------------------------------------
     def forward_post(self, node, tensors) -> None:
         if self._match(node.name):
             self.collector.update_activation(node.name, tensors)

--- a/accelerator/tools/analysis/stats/storage.py
+++ b/accelerator/tools/analysis/stats/storage.py
@@ -15,6 +15,7 @@ def save_tensor_stats(
     activations: Dict[str, Dict[str, torch.Tensor]],
     gradients: Dict[str, Dict[str, torch.Tensor]],
     path: str | Path,
+    input_activations: Dict[str, Dict[str, torch.Tensor]] | None = None,
 ) -> None:
     """Save collected tensor statistics to a JSON file.
 
@@ -32,6 +33,11 @@ def save_tensor_stats(
             node: {name: _tensor_to_list(t) for name, t in stats.items()} for node, stats in gradients.items()
         },
     }
+    if input_activations is not None:
+        serializable["input_activations"] = {
+            node: {name: _tensor_to_list(t) for name, t in stats.items()}
+            for node, stats in input_activations.items()
+        }
     path = Path(path)
     if path.parent:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/model_analysis_cifar10_resnet18.py
+++ b/examples/model_analysis_cifar10_resnet18.py
@@ -31,8 +31,8 @@ def main() -> None:
         outputs.sum().backward()
         break  # collect statistics from a single batch for brevity
 
-    activations, gradients = collector.compute()
-    save_tensor_stats(activations, gradients, "resnet18_cifar10_stats.json")
+    input_activations, activations, gradients = collector.compute()
+    save_tensor_stats(activations, gradients, "resnet18_cifar10_stats.json", input_activations)
     print("Saved statistics to resnet18_cifar10_stats.json")
 
 

--- a/tests/test_stats_collectors.py
+++ b/tests/test_stats_collectors.py
@@ -27,7 +27,9 @@ def test_per_layer_channel_dim_configs():
     collector.update_gradient("layer1", [grad])
     collector.update_gradient("layer2", [grad])
 
-    activations, gradients = collector.compute()
+    input_activations, activations, gradients = collector.compute()
+
+    assert input_activations == {}
 
     assert torch.allclose(activations["layer1"]["mean"], torch.tensor([1.5, 3.5]))
     assert torch.allclose(activations["layer2"]["mean"], torch.tensor([2.0, 3.0]))

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+from torch.fx import symbolic_trace
+
+from accelerator.tools.analysis.model_analysis import NodeInterpreter, StatsRouter
+from accelerator.tools.analysis.stats.collector import StatsConfig, TensorStatsCollector
+
+
+def test_router_collects_input_stats():
+    class SimpleModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(2, 2, bias=False)
+            with torch.no_grad():
+                self.lin.weight.copy_(torch.eye(2))
+
+        def forward(self, x):
+            return self.lin(x)
+
+    model = SimpleModel()
+    gm = symbolic_trace(model)
+    cfg = StatsConfig(channel_dim=0)
+    collector = TensorStatsCollector(cfg, cfg)
+    router = StatsRouter(collector)
+    interpreter = NodeInterpreter(gm, router)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    interpreter.run(x)
+    input_acts, acts, _ = collector.compute()
+
+    assert torch.allclose(input_acts["lin"]["mean"], torch.tensor([1.5, 3.5]))


### PR DESCRIPTION
## Summary
- Add `forward_pre` hook to `StatsRouter` for capturing node inputs
- Extend `TensorStatsCollector` and storage utilities to record input activations separately
- Update CLI, examples and tests to validate input-activation statistics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50fc81c0c8325a776b2c468a8db62